### PR TITLE
Replaces standard pipeline w/Blue Green.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ Available targets:
 | webhook_filter_json_path | The JSON path to filter on. | string | `$.ref` | no |
 | webhook_filter_match_equals | The value to match on (e.g. refs/heads/{Branch}) | string | `refs/heads/{Branch}` | no |
 | webhook_target_action | The name of the action in a pipeline you want to connect to the webhook. The action must be from the source (first) stage of the pipeline. | string | `Source` | no |
-| blue_green_enabled | Whether to deploy using ECS Blue/Green. | string | `false` | no |
 | code_deploy_application_name | Code Deploy application name. | string | `` | no |
 | code_deploy_deployment_group_name | Code Deploy deployment group name. | string | `` | no |
+| code_deploy_sns_topic_arn | The SNS topic to send notification messages. | string | `` | no |
+| code_deploy_lambda_hook_arns | The lambda arns this code depoloy app should be permitted to access. | string | `` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers 
 
 ---
 
-This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps. 
+This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
 [<img align="right" title="Share via Email" src="https://docs.cloudposse.com/images/ionicons/ios-email-outline-2.0.1-16x16-999999.svg"/>][share_email]
 [<img align="right" title="Share on Google+" src="https://docs.cloudposse.com/images/ionicons/social-googleplus-outline-2.0.1-16x16-999999.svg" />][share_googleplus]
 [<img align="right" title="Share on Facebook" src="https://docs.cloudposse.com/images/ionicons/social-facebook-outline-2.0.1-16x16-999999.svg" />][share_facebook]
@@ -32,7 +32,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
-We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out! 
+We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
 
 
 
@@ -180,6 +180,9 @@ Available targets:
 | webhook_filter_json_path | The JSON path to filter on. | string | `$.ref` | no |
 | webhook_filter_match_equals | The value to match on (e.g. refs/heads/{Branch}) | string | `refs/heads/{Branch}` | no |
 | webhook_target_action | The name of the action in a pipeline you want to connect to the webhook. The action must be from the source (first) stage of the pipeline. | string | `Source` | no |
+| blue_green_enabled | Whether to deploy using ECS Blue/Green. | string | `false` | no |
+| code_deploy_application_name | Code Deploy application name. | string | `` | no |
+| code_deploy_deployment_group_name | Code Deploy deployment group name. | string | `` | no |
 
 ## Outputs
 
@@ -192,9 +195,9 @@ Available targets:
 
 
 
-## Share the Love 
+## Share the Love
 
-Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-ecs-codepipeline)! (it helps us **a lot**) 
+Like this project? Please give it a ★ on [our GitHub](https://github.com/cloudposse/terraform-aws-ecs-codepipeline)! (it helps us **a lot**)
 
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
@@ -216,7 +219,7 @@ Check out these related projects.
 
 ## References
 
-For additional context, refer to some of these links. 
+For additional context, refer to some of these links.
 
 - [aws_codepipeline_webhook](https://www.terraform.io/docs/providers/aws/r/codepipeline_webhook.html) - Provides a CodePipeline Webhook
 
@@ -231,9 +234,9 @@ File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-codepipeli
 
 ## Commercial Support
 
-Work directly with our team of DevOps experts via email, slack, and video conferencing. 
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
 
-We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer.
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)][email]
 
@@ -243,7 +246,7 @@ We provide [*commercial support*][commercial_support] for all of our [Open Sourc
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll [develop original modules][module_development] to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures.
 
 
 
@@ -258,7 +261,7 @@ Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Ou
 
 ## Newsletter
 
-Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover. 
+Signup for [our newsletter][newsletter] that covers everything on our technology radar.  Receive updates on what we're up to on GitHub as well as awesome new projects we discover.
 
 ## Contributing
 
@@ -287,9 +290,9 @@ Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 
-## License 
+## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 
@@ -330,7 +333,7 @@ This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? P
 
 We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We ❤️  [Open Source Software][we_love_open_source].
 
-We offer [paid support][commercial_support] on all of our projects.  
+We offer [paid support][commercial_support] on all of our projects.
 
 Check out [our other projects][github], [follow us on twitter][twitter], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 [![Cloud Posse][logo]](https://cpco.io/homepage)
 
-# terraform-aws-ecs-codepipeline [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ecs-codepipeline.svg)](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+# terraform-aws-ecs-codepipeline-bg [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ecs-codepipeline.svg)](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS.
+Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS Blue/Green.
 
 
 ---
@@ -53,7 +53,7 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
 In this example, we'll trigger the pipeline anytime the `master` branch is updated.
 ```hcl
 module "ecs_push_pipeline" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
+  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
   name               = "app"
   namespace          = "eg"
   stage              = "staging"
@@ -73,7 +73,7 @@ In this example, we'll trigger anytime a new GitHub release is cut by setting th
 
 ```hcl
 module "ecs_release_pipeline" {
-  source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
+  source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
   name                        = "app"
   namespace                   = "eg"
   stage                       = "staging"
@@ -229,7 +229,7 @@ For additional context, refer to some of these links.
 
 **Got a question?**
 
-File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/issues), send us an [email][email] or join our [Slack Community][slack].
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg/issues), send us an [email][email] or join our [Slack Community][slack].
 
 [![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Available targets:
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | ecs_cluster_name | ECS Cluster Name | string | - | yes |
 | enabled | Enable `CodePipeline` creation | string | `true` | no |
+| pipeline_bucket_lifecycle_enabled | Enable bucket lifecycle rules. | string | `false` | no |
+| pipeline_bucket_lifecycle_expiration_days | The amount of days before expiring a bucket object | string | `60` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build. | list | `<list>` | no |
 | github_oauth_token | GitHub OAuth Token with permissions to access private repositories | string | - | yes |
 | github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list | `<list>` | no |

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 [![Cloud Posse][logo]](https://cpco.io/homepage)
 
-# terraform-aws-ecs-codepipeline-bg [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ecs-codepipeline.svg)](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+# terraform-aws-ecs-codepipeline [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-ecs-codepipeline) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ecs-codepipeline.svg)](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS Blue/Green.
+Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS.
 
 
 ---
@@ -53,7 +53,7 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
 In this example, we'll trigger the pipeline anytime the `master` branch is updated.
 ```hcl
 module "ecs_push_pipeline" {
-  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
+  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
   name               = "app"
   namespace          = "eg"
   stage              = "staging"
@@ -73,7 +73,7 @@ In this example, we'll trigger anytime a new GitHub release is cut by setting th
 
 ```hcl
 module "ecs_release_pipeline" {
-  source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
+  source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
   name                        = "app"
   namespace                   = "eg"
   stage                       = "staging"
@@ -230,7 +230,7 @@ For additional context, refer to some of these links.
 
 **Got a question?**
 
-File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg/issues), send us an [email][email] or join our [Slack Community][slack].
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/issues), send us an [email][email] or join our [Slack Community][slack].
 
 [![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Available targets:
 | badge_url | The URL of the build badge when badge_enabled is enabled |
 | webhook_id | The CodePipeline webhook's ARN. |
 | webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
+| default_role_arn | The CodePipeline role arn |
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -5,7 +5,7 @@
 #
 
 # Name of this project
-name: terraform-aws-ecs-codepipeline
+name: terraform-aws-ecs-codepipeline-bg
 
 # Logo for this project
 #logo: docs/logo.png
@@ -53,7 +53,7 @@ related:
 
 # Short description of this project
 description: |-
-  Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS.
+  Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS Blue/Green.
 
 # How to use this project
 usage: |-
@@ -63,7 +63,7 @@ usage: |-
   In this example, we'll trigger the pipeline anytime the `master` branch is updated.
   ```hcl
   module "ecs_push_pipeline" {
-    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
+    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
     name               = "app"
     namespace          = "eg"
     stage              = "staging"
@@ -83,7 +83,7 @@ usage: |-
 
   ```hcl
   module "ecs_release_pipeline" {
-    source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
+    source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
     name                        = "app"
     namespace                   = "eg"
     stage                       = "staging"

--- a/README.yaml
+++ b/README.yaml
@@ -63,7 +63,7 @@ usage: |-
   In this example, we'll trigger the pipeline anytime the `master` branch is updated.
   ```hcl
   module "ecs_push_pipeline" {
-    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
+    source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
     name               = "app"
     namespace          = "eg"
     stage              = "staging"
@@ -83,7 +83,7 @@ usage: |-
 
   ```hcl
   module "ecs_release_pipeline" {
-    source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline-bg.git?ref=master"
+    source                      = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=master"
     name                        = "app"
     namespace                   = "eg"
     stage                       = "staging"

--- a/README.yaml
+++ b/README.yaml
@@ -5,7 +5,7 @@
 #
 
 # Name of this project
-name: terraform-aws-ecs-codepipeline-bg
+name: terraform-aws-ecs-codepipeline
 
 # Logo for this project
 #logo: docs/logo.png
@@ -53,7 +53,7 @@ related:
 
 # Short description of this project
 description: |-
-  Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS Blue/Green.
+  Terraform Module for CI/CD with AWS Code Pipeline using GitHub webhook triggers and Code Build for ECS.
 
 # How to use this project
 usage: |-

--- a/bg.tf
+++ b/bg.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role_policy_attachment" "ecs_limited" {
   role       = "${aws_iam_role.default.id}"
-  policy_arn = "${aws_iam_policy.ecs_limited}"
+  policy_arn = "${aws_iam_policy.ecs_limited.arn}"
 }
 
 module "codepipeline_ecs_limited_policy_label" {

--- a/bg.tf
+++ b/bg.tf
@@ -1,0 +1,79 @@
+resource "aws_codepipeline" "source_build_deploy" {
+  count    = "${local.enabled * local.blue_green_enabled ? 1 : 0}"
+  name     = "${module.codepipeline_label.id}"
+  role_arn = "${aws_iam_role.default.arn}"
+
+  artifact_store {
+    location = "${aws_s3_bucket.default.bucket}"
+    type     = "S3"
+  }
+
+  depends_on = [
+    "aws_iam_role_policy_attachment.default",
+    "aws_iam_role_policy_attachment.s3",
+    "aws_iam_role_policy_attachment.codebuild",
+    "aws_iam_role_policy_attachment.codebuild_s3",
+  ]
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["code"]
+
+      configuration {
+        OAuthToken           = "${var.github_oauth_token}"
+        Owner                = "${var.repo_owner}"
+        Repo                 = "${var.repo_name}"
+        Branch               = "${var.branch}"
+        PollForSourceChanges = "${var.poll_source_changes}"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name     = "Build"
+      category = "Build"
+      owner    = "AWS"
+      provider = "CodeBuild"
+      version  = "1"
+
+      input_artifacts  = ["code"]
+      output_artifacts = ["task"]
+
+      configuration {
+        ProjectName = "${module.build.project_name}"
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+
+    action {
+      name            = "Deploy"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "CodeDeployToECS"
+      input_artifacts = ["task"]
+      version         = "1"
+
+      configuration {
+        ApplicationName                = "${var.code_deploy_application_name}"
+        DeploymentGroupName            = "${var.code_deploy_deployment_group_name}"
+        TaskDefinitionTemplateArtifact = "task"
+        TaskDefinitionTemplatePath     = "taskDef.json"
+        AppSpecTemplateArtifact        = "task"
+        AppSpecTemplatePath            = "appspec.yaml"
+      }
+    }
+  }
+}

--- a/bg.tf
+++ b/bg.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "ecs_limited" {
 
     resources = [
       "arn:aws:iam::*:role/ecsTaskExecutionRole",
-      "arn::aws:iam::*:role/ECSTaskExecution*"
+      "arn:aws:iam::*:role/ECSTaskExecution*"
     ]
     condition {
       test     = "StringLike"

--- a/bg.tf
+++ b/bg.tf
@@ -1,4 +1,4 @@
-resource "aws_codepipeline" "source_build_deploy" {
+resource "aws_codepipeline" "source_build_deploy_bg" {
   count    = "${local.enabled * local.blue_green_enabled ? 1 : 0}"
   name     = "${module.codepipeline_label.id}"
   role_arn = "${aws_iam_role.default.arn}"

--- a/bg.tf
+++ b/bg.tf
@@ -1,5 +1,5 @@
 resource "aws_codepipeline" "source_build_deploy_bg" {
-  count    = "${local.enabled * local.blue_green_enabled ? 1 : 0}"
+  count    = "${local.enabled && local.blue_green_enabled ? 1 : 0}"
   name     = "${module.codepipeline_label.id}"
   role_arn = "${aws_iam_role.default.arn}"
 

--- a/bg.tf
+++ b/bg.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "ecs_limited" {
       "elasticloadbalancing:ModifyRule"
     ]
 
-    resources = "*"
+    resources = ["*"]
     effect    = "Allow"
   }
 
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "ecs_limited" {
       "s3:GetObjectVersion"
     ]
 
-    resources  = "*"
+    resources  = ["*"]
 
     condition {
       test     = "StringEquals"
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "ecs_limited" {
     condition {
       test     = "StringLike"
       variable = "iam:PassedToService"
-      values   = "ecs-tasks.amazonaws.com"
+      values   = ["ecs-tasks.amazonaws.com"]
     }
   }
 }

--- a/bg.tf
+++ b/bg.tf
@@ -105,7 +105,12 @@ module "codepipeline_codedeploy_policy_label" {
   tags       = "${var.tags}"
 }
 
-resource "aws_iam_policy" "ecs_limited" {
+resource "aws_iam_role_policy_attachment" "deploy" {
+  role       = "${aws_iam_role.default.id}"
+  policy_arn = "${aws_iam_policy.deploy.arn}"
+}
+
+resource "aws_iam_policy" "deploy" {
   name   = "${module.codepipeline_codedeploy_policy_label.id}"
   policy = "${data.aws_iam_policy_document.deploy.json}"
 }
@@ -146,6 +151,8 @@ resource "aws_codepipeline" "source_build_deploy_bg" {
     "aws_iam_role_policy_attachment.s3",
     "aws_iam_role_policy_attachment.codebuild",
     "aws_iam_role_policy_attachment.codebuild_s3",
+    "aws_iam_role_policy_attachment.deploy",
+    "aws_iam_role_policy_attachment.ecs_limited",
   ]
 
   stage {

--- a/bg.tf
+++ b/bg.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "ecs_limited" {
 
   statement {
     actions   = ["sns:publish"]
-    resources = ["${var.code_deploy_sns_topic_arn == "" ? "" : var.code_deploy_sns_topic_arn}"]
+    resources = ["${var.code_deploy_sns_topic_arn == "" ? "" : var.code_deploy_sns_topic_arn}", "arn:aws:sns:*:*:CodeDeployTopic_*"]
     effect    = "Allow"
   }
 
@@ -84,14 +84,8 @@ data "aws_iam_policy_document" "ecs_limited" {
     actions = ["iam:PassRole"]
 
     resources = [
-      "arn:aws:iam::*:role/ecsTaskExecutionRole",
-      "arn:aws:iam::*:role/ECSTaskExecution*"
+      "*"
     ]
-    condition {
-      test     = "StringLike"
-      variable = "iam:PassedToService"
-      values   = ["ecs-tasks.amazonaws.com"]
-    }
   }
 }
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,9 +35,10 @@
 | webhook_filter_json_path | The JSON path to filter on. | string | `$.ref` | no |
 | webhook_filter_match_equals | The value to match on (e.g. refs/heads/{Branch}) | string | `refs/heads/{Branch}` | no |
 | webhook_target_action | The name of the action in a pipeline you want to connect to the webhook. The action must be from the source (first) stage of the pipeline. | string | `Source` | no |
-| blue_green_enabled | Whether to deploy using ECS Blue/Green. | string | `false` | no |
 | code_deploy_application_name | Code Deploy application name. | string | `` | no |
 | code_deploy_deployment_group_name | Code Deploy deployment group name. | string | `` | no |
+| code_deploy_sns_topic_arn | The SNS topic to send notification messages. | string | `` | no |
+| code_deploy_lambda_hook_arns | The lambda arns this code depoloy app should be permitted to access. | string | `` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -35,6 +35,9 @@
 | webhook_filter_json_path | The JSON path to filter on. | string | `$.ref` | no |
 | webhook_filter_match_equals | The value to match on (e.g. refs/heads/{Branch}) | string | `refs/heads/{Branch}` | no |
 | webhook_target_action | The name of the action in a pipeline you want to connect to the webhook. The action must be from the source (first) stage of the pipeline. | string | `Source` | no |
+| blue_green_enabled | Whether to deploy using ECS Blue/Green. | string | `false` | no |
+| code_deploy_application_name | Code Deploy application name. | string | `` | no |
+| code_deploy_deployment_group_name | Code Deploy deployment group name. | string | `` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -47,4 +47,4 @@
 | badge_url | The URL of the build badge when badge_enabled is enabled |
 | webhook_id | The CodePipeline webhook's ARN. |
 | webhook_url | The CodePipeline webhook's URL. POST events to this endpoint to trigger the target |
-
+| default_role_arn | The CodePipeline role arn |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,8 @@
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | ecs_cluster_name | ECS Cluster Name | string | - | yes |
 | enabled | Enable `CodePipeline` creation | string | `true` | no |
+| pipeline_bucket_lifecycle_enabled | Enable bucket lifecycle rules. | string | `false` | no |
+| pipeline_bucket_lifecycle_expiration_days | The amount of days before expiring a bucket object | string | `60` | no |
 | environment_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build. | list | `<list>` | no |
 | github_oauth_token | GitHub OAuth Token with permissions to access private repositories | string | - | yes |
 | github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   enabled = "${var.enabled == "true" ? true : false}"
+  blue_green_enabled = "${var.blue_green_enabled == "true" ? true : false}"
 }
 
 module "codepipeline_label" {
@@ -201,7 +202,7 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 }
 
 resource "aws_codepipeline" "source_build_deploy" {
-  count    = "${local.enabled ? 1 : 0}"
+  count    = "${local.enabled * local.blue_green_enabled ? 0 : 1}"
   name     = "${module.codepipeline_label.id}"
   role_arn = "${aws_iam_role.default.arn}"
 

--- a/main.tf
+++ b/main.tf
@@ -295,7 +295,7 @@ resource "aws_codepipeline_webhook" "webhook" {
   name            = "${module.codepipeline_label.id}"
   authentication  = "${var.webhook_authentication}"
   target_action   = "${var.webhook_target_action}"
-  target_pipeline = "${join("", aws_codepipeline.source_build_deploy.*.name)}"
+  target_pipeline = "${var.blue_green_enabled == "true" ? join("", aws_codepipeline.source_build_deploy_bg.*.name) : join("", aws_codepipeline.source_build_deploy.*.name)}"
 
   authentication_configuration {
     secret_token = "${local.webhook_secret}"

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   enabled = "${var.enabled == "true" ? true : false}"
-  blue_green_enabled = "${var.blue_green_enabled == "true" ? true : false}"
 }
 
 module "codepipeline_label" {
@@ -47,7 +46,7 @@ data "aws_iam_policy_document" "assume" {
 
     principals {
       type        = "Service"
-      identifiers = ["codepipeline.amazonaws.com"]
+      identifiers = ["codepipeline.amazonaws.com", "codedeploy.amazonaws.com"]
     }
 
     effect = "Allow"
@@ -201,82 +200,6 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
   policy_arn = "${aws_iam_policy.s3.arn}"
 }
 
-resource "aws_codepipeline" "source_build_deploy" {
-  count    = "${local.enabled && local.blue_green_enabled ? 0 : 1}"
-  name     = "${module.codepipeline_label.id}"
-  role_arn = "${aws_iam_role.default.arn}"
-
-  artifact_store {
-    location = "${aws_s3_bucket.default.bucket}"
-    type     = "S3"
-  }
-
-  depends_on = [
-    "aws_iam_role_policy_attachment.default",
-    "aws_iam_role_policy_attachment.s3",
-    "aws_iam_role_policy_attachment.codebuild",
-    "aws_iam_role_policy_attachment.codebuild_s3",
-  ]
-
-  stage {
-    name = "Source"
-
-    action {
-      name             = "Source"
-      category         = "Source"
-      owner            = "ThirdParty"
-      provider         = "GitHub"
-      version          = "1"
-      output_artifacts = ["code"]
-
-      configuration {
-        OAuthToken           = "${var.github_oauth_token}"
-        Owner                = "${var.repo_owner}"
-        Repo                 = "${var.repo_name}"
-        Branch               = "${var.branch}"
-        PollForSourceChanges = "${var.poll_source_changes}"
-      }
-    }
-  }
-
-  stage {
-    name = "Build"
-
-    action {
-      name     = "Build"
-      category = "Build"
-      owner    = "AWS"
-      provider = "CodeBuild"
-      version  = "1"
-
-      input_artifacts  = ["code"]
-      output_artifacts = ["task"]
-
-      configuration {
-        ProjectName = "${module.build.project_name}"
-      }
-    }
-  }
-
-  stage {
-    name = "Deploy"
-
-    action {
-      name            = "Deploy"
-      category        = "Deploy"
-      owner           = "AWS"
-      provider        = "ECS"
-      input_artifacts = ["task"]
-      version         = "1"
-
-      configuration {
-        ClusterName = "${var.ecs_cluster_name}"
-        ServiceName = "${var.service_name}"
-      }
-    }
-  }
-}
-
 resource "random_string" "webhook_secret" {
   count  = "${local.enabled && var.webhook_enabled == "true" ? 1 : 0}"
   length = 32
@@ -295,7 +218,7 @@ resource "aws_codepipeline_webhook" "webhook" {
   name            = "${module.codepipeline_label.id}"
   authentication  = "${var.webhook_authentication}"
   target_action   = "${var.webhook_target_action}"
-  target_pipeline = "${var.blue_green_enabled == "true" ? join("", aws_codepipeline.source_build_deploy_bg.*.name) : join("", aws_codepipeline.source_build_deploy.*.name)}"
+  target_pipeline = "${join("", aws_codepipeline.source_build_deploy_bg.*.name)}"
 
   authentication_configuration {
     secret_token = "${local.webhook_secret}"

--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,7 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 }
 
 resource "aws_codepipeline" "source_build_deploy" {
-  count    = "${local.enabled * local.blue_green_enabled ? 0 : 1}"
+  count    = "${local.enabled && local.blue_green_enabled ? 0 : 1}"
   name     = "${module.codepipeline_label.id}"
   role_arn = "${aws_iam_role.default.arn}"
 

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,32 @@ resource "aws_s3_bucket" "default" {
   acl           = "private"
   force_destroy = "${var.s3_bucket_force_destroy}"
   tags          = "${module.codepipeline_label.tags}"
+
+  lifecycle_rule {
+    id      = "code"
+    enabled = "${var.pipeline_bucket_lifecycle_enabled}"
+
+    prefix  = "${format("%s/code/", module.codebuild_label.id)}"
+    noncurrent_version_expiration {
+      days = "${var.pipeline_bucket_lifecycle_expiration_days}"
+    }
+    expiration {
+      days = "${var.pipeline_bucket_lifecycle_expiration_days}"
+    }
+  }
+
+  lifecycle_rule {
+    id      = "task"
+    enabled = "${var.pipeline_bucket_lifecycle_enabled}"
+
+    prefix  = "${format("%s/task/", module.codebuild_label.id)}"
+    noncurrent_version_expiration {
+      days = "${var.pipeline_bucket_lifecycle_expiration_days}"
+    }
+    expiration {
+      days = "${var.pipeline_bucket_lifecycle_expiration_days}"
+    }
+  }
 }
 
 module "codepipeline_assume_label" {

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "default" {
     id      = "code"
     enabled = "${var.pipeline_bucket_lifecycle_enabled}"
 
-    prefix  = "${format("%s/code/", module.codebuild_label.id)}"
+    prefix  = "${format("%.20s/code/", module.codebuild_label.id)}"
     noncurrent_version_expiration {
       days = "${var.pipeline_bucket_lifecycle_expiration_days}"
     }
@@ -36,7 +36,7 @@ resource "aws_s3_bucket" "default" {
     id      = "task"
     enabled = "${var.pipeline_bucket_lifecycle_enabled}"
 
-    prefix  = "${format("%s/task/", module.codebuild_label.id)}"
+    prefix  = "${format("%.20s/task/", module.codebuild_label.id)}"
     noncurrent_version_expiration {
       days = "${var.pipeline_bucket_lifecycle_expiration_days}"
     }

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,5 +16,5 @@ output "webhook_url" {
 
 output "default_role_arn" {
   description = "The CodePipeline Service Role Arn"
-  value       = "${aws_iam_role.default.arn}"
+  value       = "${join("", aws_iam_role.default.*.arn)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,8 @@ output "webhook_url" {
   value       = "${local.webhook_url}"
   sensitive   = true
 }
+
+output "default_role_arn" {
+  description = "The CodePipeline Service Role Arn"
+  value       = "${aws_iam_role.default.arn}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -182,7 +182,7 @@ variable "s3_bucket_force_destroy" {
 
 variable "blue_green_enabled" {
   description = "A boolean that indicates whether the deployment should use blue green."
-  default     = false
+  default     = "false"
 }
 
 variable "code_deploy_application_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,18 @@ variable "s3_bucket_force_destroy" {
   description = "A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error"
   default     = false
 }
+
+variable "blue_green_enabled" {
+  description = "A boolean that indicates whether the deployment should use blue green."
+  default     = false
+}
+
+variable "code_deploy_application_name" {
+  description = "The application name for CodeDeployToECS"
+  default     = ""
+}
+
+variable "code_deploy_deployment_group_name" {
+  description = "The group name for CodeDeployToECS"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -180,11 +180,6 @@ variable "s3_bucket_force_destroy" {
   default     = false
 }
 
-variable "blue_green_enabled" {
-  description = "A boolean that indicates whether the deployment should use blue green."
-  default     = "false"
-}
-
 variable "code_deploy_application_name" {
   description = "The application name for CodeDeployToECS"
   default     = ""
@@ -192,5 +187,15 @@ variable "code_deploy_application_name" {
 
 variable "code_deploy_deployment_group_name" {
   description = "The group name for CodeDeployToECS"
+  default     = ""
+}
+
+variable "code_deploy_sns_topic_arn" {
+  description = "The SNS topic to send notification messages"
+  default     = ""
+}
+
+variable "code_deploy_lambda_hook_arns" {
+  description = "The lambda arns this code depoloy app should be permitted to access."
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,16 @@ variable "enabled" {
   description = "Enable `CodePipeline` creation"
 }
 
+variable "pipeline_bucket_lifecycle_enabled" {
+  default     = "false"
+  description = "Enable bucket lifecycle rules."
+}
+
+variable "pipeline_bucket_lifecycle_expiration_days" {
+  default     = "60"
+  description = "The amount of days before expiring a bucket object; default:60."
+}
+
 variable "ecs_cluster_name" {
   type        = "string"
   description = "ECS Cluster Name"


### PR DESCRIPTION
Here is a meaty one.

- Removes standard pipeline.
- Replaces it w/CodeDeployToECS for B/G deployment.
- Adds codepipeline bucket lifecycle rules.

This is a huge departure from the original pipeline.  We should actually allow for choice b/w ECS and CodeDeployToECS. This works for what we want to do. Perhaps in the near future we can either allow for the choice or hard separate it into its own module. 
